### PR TITLE
fixed typo of "successful" in src and test

### DIFF
--- a/spring-security-kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
+++ b/spring-security-kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
@@ -68,7 +68,7 @@ public class SunJaasKerberosTicketValidator implements KerberosTicketValidator, 
             return Subject.doAs(this.serviceSubject, new KerberosValidateAction(token));
         }
         catch (PrivilegedActionException e) {
-            throw new BadCredentialsException("Kerberos validation not succesful", e);
+            throw new BadCredentialsException("Kerberos validation not successful", e);
         }
     }
 

--- a/spring-security-kerberos-core/src/test/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidatorTests.java
+++ b/spring-security-kerberos-core/src/test/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidatorTests.java
@@ -73,7 +73,7 @@ public class SunJaasKerberosTicketValidatorTests {
 	public void testJdkMsKrb5OIDRegressionTweak() throws Exception {
 		thrown.expect(BadCredentialsException.class);
 		thrown.expectMessage(not(containsString("GSSContext name of the context initiator is null")));
-		thrown.expectMessage(containsString("Kerberos validation not succesful"));
+		thrown.expectMessage(containsString("Kerberos validation not successful"));
 		SunJaasKerberosTicketValidator validator = new SunJaasKerberosTicketValidator();
 		byte[] kerberosTicket = Base64.decode(header.getBytes());
 		validator.validateTicket(kerberosTicket);


### PR DESCRIPTION
Fixed a couple of typo'd instances of "successful" (was "succesful"). 

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.