### PR TITLE
Fix compile for sec 4.x

### DIFF
--- a/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/ldap/KerberosLdapContextSource.java
+++ b/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/ldap/KerberosLdapContextSource.java
@@ -87,8 +87,16 @@ public class KerberosLdapContextSource extends DefaultSpringSecurityContextSourc
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	public void afterPropertiesSet() /*throws Exception*/ {
+		// org.springframework.ldap.core.support.AbstractContextSource in 4.x
+		// doesn't throw Exception for its InitializingBean method, so
+		// we had to remove it from here also. Addition to that
+		// we need to catch super call and re-throw.
+		try {
+			super.afterPropertiesSet();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 		Assert.notNull(this.loginConfig, "loginConfig must be specified");
 	}
 

--- a/spring-security-kerberos-samples/sec-server-spnego-form-auth-xml/src/main/resources/websecurityconfig.xml
+++ b/spring-security-kerberos-samples/sec-server-spnego-form-auth-xml/src/main/resources/websecurityconfig.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 


### PR DESCRIPTION
- Fixes #33
- In websecurityconfig, use default xsd. With 4.x sec core's
  namespace handler barks if 3.x is in use.
- Doing tweaks in KerberosLdapContextSource to overcome trouble
  with ldap's AbstractContextSource which wrongly removed
  throwing exception from its overridded afterPropertiesSet()
  method. Remove throw and re-throw super call.