### PR TITLE
Update documentation URLs in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,8 +6,8 @@ With the Spring Security Kerberos Extension, your users are authenticated agains
 See https://github.com/spring-projects/spring-framework/wiki/Downloading-Spring-artifacts[downloading Spring artifacts] for Maven repository information.
 
 == Documentation
-Be sure to read the http://docs.spring.io/spring-security-kerberos/docs/1.0.0.BUILD-SNAPSHOT/reference/htmlsingle/[Spring Security Kerberos Reference].
-Extensive JavaDoc for the Spring Security Kerberos code is also available in the http://docs.spring.io/spring-security-kerberos/docs/1.0.0.BUILD-SNAPSHOT/api/[Spring Security Kerberos API Documentation].
+Be sure to read the http://docs.spring.io/spring-security-kerberos/docs/1.0.x/reference/htmlsingle/[Spring Security Kerberos Reference].
+Extensive JavaDoc for the Spring Security Kerberos code is also available in the http://docs.spring.io/spring-security-kerberos/docs/1.0.x/api/[Spring Security Kerberos API Documentation].
 
 == Samples
 Samples can be found under `spring-security-kerberos-samples`. Check


### PR DESCRIPTION
Point to docs/1.0.x instead of docs/1.0.0.BUILD-SNAPSHOT to be up to date and a bit more future-proof.