### PR TITLE
Do not handle NTLM authentication requests

### DIFF
--- a/spring-security-kerberos-web/src/main/java/org/springframework/security/kerberos/web/authentication/SpnegoAuthenticationProcessingFilter.java
+++ b/spring-security-kerberos-web/src/main/java/org/springframework/security/kerberos/web/authentication/SpnegoAuthenticationProcessingFilter.java
@@ -115,6 +115,14 @@ public class SpnegoAuthenticationProcessingFilter extends GenericFilterBean {
     private SessionAuthenticationStrategy sessionStrategy = new NullAuthenticatedSessionStrategy();
     private boolean skipIfAlreadyAuthenticated = true;
 
+    /**
+     * Authentication header prefix sent by IE/Windows when the domain controller fails to issue a Kerberos
+     * ticket for the URL.
+     *
+     * "TlRMTVNTUA" is the base64 encoding of "NTLMSSP". This will be followed by the actual token.
+     **/
+    private static final String NTLMSSP_PREFIX = "Negotiate TlRMTVNTUA";
+
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) req;
@@ -132,7 +140,7 @@ public class SpnegoAuthenticationProcessingFilter extends GenericFilterBean {
 
         String header = request.getHeader("Authorization");
 
-        if (header != null && (header.startsWith("Negotiate ") || header.startsWith("Kerberos "))) {
+        if (header != null && ((header.startsWith("Negotiate ") && !header.startsWith(NTLMSSP_PREFIX)) || header.startsWith("Kerberos "))) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Received Negotiate Header for request " + request.getRequestURL() + ": " + header);
             }


### PR DESCRIPTION
Avoid handling NTLM authentication requests in the SpnegoAuthenticationProcessingFilter, since the payload is not a valid Spnego token.

These tokens are currently treated as a SpNego token and passed to the GSSAPI, which throws an exception `GSSException: Defective token detected (Mechanism level: GSSHeader did not find the right tag)`.

Depending on the error handler, IE may think that it successfully authenticated via NTLM and/or continue to sent NTLM tokens on subsequent requests.
IE also likes to preemtively send NTLM tokens when posting forms (i.e. instead of posting a FORM with the actual data, it sends a zero-byte POST with an NTLM header, expects the server to issue an NTLM challenge and will ultimately retry the POST once it's confident that it's authorized.
This breaks badly when servers don't actually implement NTLM authentication.
