### PR TITLE
Avoid pass null principal name when use cached tkt

### DIFF
--- a/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
+++ b/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
@@ -178,8 +178,14 @@ public class KerberosRestTemplate extends RestTemplate {
 
 		try {
 			ClientLoginConfig loginConfig = new ClientLoginConfig(keyTabLocation, userPrincipal, loginOptions);
-			Set<Principal> princ = new HashSet<Principal>(1);
-			princ.add(new KerberosPrincipal(userPrincipal));
+			Set<Principal> princ;
+			if (userPrincipal != null) {
+				princ = new HashSet<Principal>(1);
+                            	princ.add(new KerberosPrincipal(userPrincipal));
+            		}
+			else {
+				princ = Collections.<Principal>emptySet();
+			}
 			Subject sub = new Subject(false, princ, new HashSet<Object>(), new HashSet<Object>());
 			LoginContext lc = new LoginContext("", sub, null, loginConfig);
 			lc.login();


### PR DESCRIPTION
otherwise, you will get NPE when creating "KerberosPrincipal" instance