### PR TITLE
Added optional gss config file to GlobalSunJaasKerberosConfig

### DIFF
--- a/spring-security-kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/GlobalSunJaasKerberosConfig.java
+++ b/spring-security-kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/GlobalSunJaasKerberosConfig.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.security.kerberos.authentication.sun;
 
+import java.security.Security;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -30,6 +32,8 @@ public class GlobalSunJaasKerberosConfig implements BeanPostProcessor, Initializ
     private boolean debug = false;
 
     private String krbConfLocation;
+    
+    private String gssConfLocation;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -39,7 +43,12 @@ public class GlobalSunJaasKerberosConfig implements BeanPostProcessor, Initializ
         if (krbConfLocation != null) {
             System.setProperty("java.security.krb5.conf", krbConfLocation);
         }
-
+        if (gssConfLocation != null) {
+            System.setProperty("java.security.auth.login.config", gssConfLocation);
+        	Security.setProperty("policy.allowSystemProperty", "true");
+        } else {
+        	Security.setProperty("policy.allowSystemProperty", "false");
+        }
     }
 
     /**
@@ -59,6 +68,15 @@ public class GlobalSunJaasKerberosConfig implements BeanPostProcessor, Initializ
     public void setKrbConfLocation(String krbConfLocation) {
         this.krbConfLocation = krbConfLocation;
     }
+    
+    /**
+     * GSS config file location can be specified here.
+     * 
+     * @param gssConfLocation the path to the gss config file
+     */
+    public void setGssConfLocation(String gssConfLocation) {
+		this.gssConfLocation = gssConfLocation;
+	}
 
     //  The following methods are not used here. This Bean implements only BeanPostProcessor to ensure that it
     //  is created before any other bean is created, because the system properties needed to be set very early


### PR DESCRIPTION
Moving from java 7 to java 8 suddenly the GSSContext.acceptSecContext(kerberosTicket, 0, kerberosTicket.length) raised an exception due to a missing file: gss.conf.
Turns out the config lookup in ConfigFile$Spi.<init>() now uses two environment variables to find a config file:
  'policy.allowSystemProperty'
and
  'java.security.auth.login.config'
and then fails if such defined file is not present.

As a result the SunJaasKerberosTicketValidator is now affeced by other services on the classpath setting 'java.security.auth.login.config' to non existing resources, like for example the Smack SASLGSSAPIMechanism which configures a non existing 'gss.conf' as 'java.se

This patch links the 'policy.allowSystemProperty' to an optional 'java.security.auth.login.config' managed by GlobalSunJaasKerberosConfig. This way the ConfigFile$Spi.<init>() will omit any 'java.security.auth.login.config' that is unknown toGlobalSunJaasKerberosConf
Configurations with custom config files are also still possible.

Change-Id: I07a1a2a2cc95c1338b981a2737f59b0517493526
