### PR TITLE
Update hyperlink to Pro Git chapter and tweak anchor text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Please carefully follow the whitespace and formatting conventions already presen
 Whitespace management tips
 
 1. You can use the [AnyEdit Eclipse plugin](http://marketplace.eclipse.org/content/anyedit-tools) to ensure spaces are used and to clean up trailing whitespaces.
-1. Use git's pre-commit.sample hook to prevent invalid whitespace from being pushed out. You can enable it by moving ~/spring-security/.git/hooks/pre-commit.sample to ~/spring-security/.git/hooks/pre-commit and ensuring it is executable. For more information on hooks refer to [Pro Git's Pre-Commit Hook's section](http://git-scm.com/book/cs/ch7-3.html)
+1. Use git's pre-commit.sample hook to prevent invalid whitespace from being pushed out. You can enable it by moving ~/spring-security/.git/hooks/pre-commit.sample to ~/spring-security/.git/hooks/pre-commit and ensuring it is executable. For more information on hooks refer to [Pro Git's section on Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
 
 # Add Apache license header to all new classes
 


### PR DESCRIPTION
- Refer to the English version of the book instead of the Cestina
  version
- Refer to the second edition of the book
- Use the absolute link to the page instead of referring to the chapter
  and subsection (since these have changed in the second edition and
  could change in a future edition)
- Redo anchor text to eliminate misuse of apostrophe

Fixes gh-113