### PR TITLE
Fix sample for later versions

### DIFF
--- a/spring-security-kerberos-samples/sec-server-spnego-form-auth/src/main/java/demo/app/WebSecurityConfig.java
+++ b/spring-security-kerberos-samples/sec-server-spnego-form-auth/src/main/java/demo/app/WebSecurityConfig.java
@@ -46,7 +46,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 				.permitAll()
 				.and()
 			.addFilterBefore(
-					spnegoAuthenticationProcessingFilter(authenticationManagerBean()),
+					spnegoAuthenticationProcessingFilter(),
 					BasicAuthenticationFilter.class);
 	}
 
@@ -73,10 +73,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	}
 
 	@Bean
-	public SpnegoAuthenticationProcessingFilter spnegoAuthenticationProcessingFilter(
-			AuthenticationManager authenticationManager) {
+	public SpnegoAuthenticationProcessingFilter spnegoAuthenticationProcessingFilter() throws Exception {
 		SpnegoAuthenticationProcessingFilter filter = new SpnegoAuthenticationProcessingFilter();
-		filter.setAuthenticationManager(authenticationManager);
+		filter.setAuthenticationManager(authenticationManagerBean());
 		return filter;
 	}
 


### PR DESCRIPTION
Makes this sample valid for both 1.2.x and 1.4.x versions of spring boot, otherwise tomcat initializes its own authentication manager which does not use the configuration from the config class.