### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
@@ -40,7 +40,7 @@ configure(allprojects) {
 
 	repositories {
 		mavenCentral()
-		maven { url 'http://repo.spring.io/libs-release' }
+		maven { url 'https://repo.spring.io/libs-release' }
 	}
 
 	// servlet-api (2.5) and tomcat-servlet-api (3.0) classpath entries should not be
@@ -290,7 +290,7 @@ configure(rootProject) {
 		options.header = rootProject.description
 		options.splitIndex = true
 		options.links(
-			'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+			'https://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
 		)
 		source subprojects.collect { project ->
 			project.sourceSets.main.allJava

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -31,15 +31,15 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://projects.spring.io/spring-security-kerberos'
+            url = 'https://projects.spring.io/spring-security-kerberos'
             organization {
                 name = 'SpringSource'
-                url = 'http://projects.spring.io/spring-security-kerberos/'
+                url = 'https://projects.spring.io/spring-security-kerberos/'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://projects.spring.io/spring-security-kerberos/ migrated to:  
  https://projects.spring.io/spring-security-kerberos/ ([https](https://projects.spring.io/spring-security-kerberos/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector) result 301).
* http://projects.spring.io/spring-security-kerberos migrated to:  
  https://projects.spring.io/spring-security-kerberos ([https](https://projects.spring.io/spring-security-kerberos) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).