### PR TITLE
URL Cleanup

### DIFF
--- a/spring-security-kerberos-samples/sec-server-spnego-form-auth-xml/src/main/resources/websecurityconfig.xml
+++ b/spring-security-kerberos-samples/sec-server-spnego-form-auth-xml/src/main/resources/websecurityconfig.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<sec:http entry-point-ref="spnegoEntryPoint" use-expressions="true" >
 		<sec:intercept-url pattern="/" access="permitAll" />

--- a/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/AuthProviderConfig.xml
+++ b/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/AuthProviderConfig.xml
@@ -5,9 +5,9 @@
   xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-    http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+    http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+    http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
   <sec:http entry-point-ref="spnegoEntryPoint" use-expressions="true">
     <sec:intercept-url pattern="/" access="permitAll" />

--- a/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/SpnegoConfig.xml
+++ b/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/SpnegoConfig.xml
@@ -4,9 +4,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:context="http://www.springframework.org/schema/context"
-  xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+    http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <sec:http entry-point-ref="spnegoEntryPoint" use-expressions="true" >
     <sec:intercept-url pattern="/" access="permitAll" />

--- a/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/appproperties.xml
+++ b/spring-security-kerberos-web/src/test/resources/org/springframework/security/kerberos/docs/appproperties.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.1.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-4.1.xsd">
 
 	<context:property-placeholder location="app.properties"/>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/beans/spring-beans-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.2.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.2.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-4.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-4.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-4.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.2.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.2.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-4.1.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-4.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-4.1.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security.xsd ([https](https://www.springframework.org/schema/security/spring-security.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-4.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-4.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-4.1.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/context with 8 occurrences
* http://www.springframework.org/schema/security with 6 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences