### PR TITLE
Remove unused private constructor

### DIFF
--- a/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
+++ b/spring-security-kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
@@ -164,23 +164,6 @@ public class KerberosRestTemplate extends RestTemplate {
 	}
 
 	/**
-	 * Instantiates a new kerberos rest template.
-	 *
-	 * @param keyTabLocation the key tab location
-	 * @param userPrincipal the user principal
-	 * @param password the password
-	 * @param loginOptions the login options
-	 * @param httpClient the http client
-	 */
-	private KerberosRestTemplate(String keyTabLocation, String userPrincipal, String password, Map<String, Object> loginOptions, HttpClient httpClient) {
-		super(new HttpComponentsClientHttpRequestFactory(httpClient));
-		this.keyTabLocation = keyTabLocation;
-		this.userPrincipal = userPrincipal;
-		this.password = password;
-		this.loginOptions = loginOptions;
-	}
-
-	/**
 	 * Builds the default instance of {@link HttpClient} having kerberos
 	 * support.
 	 *


### PR DESCRIPTION
These constructors of KerberosRestTemplate aren‘t used.