### PR TITLE
Fix Maven-Repositories (401 unauthorized)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
 	repositories {
-		maven { url 'https://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.spring.io/plugins-release' }
+		maven { url 'https://plugins.gradle.org/m2/' }
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")


### PR DESCRIPTION
Can't resolve dependencies via https://repo.springsource.org/plugins-release due to `Received status code 401 from server: Unauthorized`.