### PR TITLE
Upgrade com.gradle.enterprise plugin to 3.16.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ servletApiVersion=6.0.0
 httpclient5Version=5.1.4
 kerbyVersion=2.0.3
 okhttp3Version=3.14.9
-gradleEnterpriseVersion=3.10.3
-springGeConventionsVersion=0.0.13
+gradleEnterpriseVersion=3.16.2
+springGeConventionsVersion=0.0.15


### PR DESCRIPTION
# Upgrade Enterprise Gradle Plugin

## Bumps
- [com.gradle.enterprise](https://plugins.gradle.org/plugin/com.gradle.enterprise) from 3.10.3 to 3.16.2
- [io.spring.ge.conventions](https://github.com/spring-io/gradle-enterprise-conventions) from 0.0.13 to 0.0.15

## Compatibility
Based on commits in spring-framework repo, internally spring team should support latest Gradle Enterprise plugin:
- Commit with note that only 3.15 version is supported: spring-projects/spring-framework@e3f185a696b0d6ca017a83366f24ed692573d14e 
- Commit with 3.16 version: spring-projects/spring-framework@b7e4fa16cae5f5a45fd661c51d558c8b9e5c39ae