### PR TITLE
Allow to provide SecurityContextRepository and SecurityContextHolderStrategy to be used

### DIFF
--- a/spring-security-kerberos-web/src/test/java/org/springframework/security/kerberos/web/SpnegoAuthenticationProcessingFilterTest.java
+++ b/spring-security-kerberos-web/src/test/java/org/springframework/security/kerberos/web/SpnegoAuthenticationProcessingFilterTest.java
@@ -41,6 +41,7 @@ import org.springframework.security.kerberos.web.authentication.SpnegoAuthentica
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.context.SecurityContextRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -145,11 +146,14 @@ public class SpnegoAuthenticationProcessingFilterTest {
     private void everythingWorks(String tokenPrefix) throws IOException,
             ServletException {
         // stubbing
+        SecurityContextRepository securityContextRepository = mock(SecurityContextRepository.class);
+        filter.setSecurityContextRepository(securityContextRepository);
         everythingWorksStub(tokenPrefix);
 
         // testing
         filter.doFilter(request, response, chain);
         verify(chain).doFilter(request, response);
+        verify(securityContextRepository).saveContext(SecurityContextHolder.getContext(), request, response);
         assertEquals(AUTHENTICATION, SecurityContextHolder.getContext().getAuthentication());
     }
 


### PR DESCRIPTION
In this PR I added fields for a `SecurityContextRepository` and a `SecurityContextHolderStrategy` und use them similar to [AbstractAuthenticationProcessingFilter#successfulAuthentication](https://github.com/spring-projects/spring-security/blob/6.3.1/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java#L320) to store the `SecurityContext` in the `SecurityContextRepository`. By default it uses `RequestAttributeSecurityContextRepository` wich is the same as in the `AbstractAuthenticationProcessingFilter`.

To finally achieve the expected result for #185 we have to configure the `SpnegoAuthenticationProcessingFilter` with at least a `HttpSessionSecurityContextRepository` or better (as far as I can tell from checking what spring-security is doing) with `new DelegatingSecurityContextRepository(new RequestAttributeSecurityContextRepository(), new HttpSessionSecurityContextRepository())`.  Using [`http.getConfigurer(SecurityContextConfigurer.class);`](https://github.com/spring-projects/spring-security/blob/6.3.1/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java#L294) should also work if the `http` object is available when creating the SPNEGO Filter.

Fixes #185 

> I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.